### PR TITLE
[1.18.x] Fix 2 spell related errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 # Fixes
 
+- Fixed a render crash with empty/invalid spells.
 - Fixed a bug where the touch shape targeted the wrong block.
 - Fixed mana creepers spawning everywhere.
 - Fixed a performance leak with boss spawning.

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/ClientInit.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/ClientInit.java
@@ -182,9 +182,9 @@ public final class ClientInit {
             ResourceLocation itemId = item.getRegistryName();
             if (itemId == null) continue;
             var api = ArsMagicaAPI.get();
-            if (item instanceof IAffinityItem || item instanceof ISpellItem) {
+            if (item instanceof IAffinityItem) {
                 for (IAffinity affinity : api.getAffinityRegistry()) {
-                    if (!IAffinity.NONE.equals(affinity.getRegistryName()) || item instanceof ISpellItem) {
+                    if (!IAffinity.NONE.equals(affinity.getRegistryName())) {
                         ForgeModelBakery.addSpecialModel(new ResourceLocation(affinity.getId().getNamespace(), "item/" + itemId.getPath() + "_" + affinity.getId().getPath()));
                     }
                 }
@@ -192,6 +192,11 @@ public final class ClientInit {
             if (item instanceof ISkillPointItem) {
                 for (ISkillPoint skillPoint : api.getSkillPointRegistry()) {
                     ForgeModelBakery.addSpecialModel(new ResourceLocation(skillPoint.getId().getNamespace(), "item/" + itemId.getPath() + "_" + skillPoint.getId().getPath()));
+                }
+            }
+            if (item instanceof ISpellItem) {
+                for (IAffinity affinity : api.getAffinityRegistry()) {
+                    ForgeModelBakery.addSpecialModel(new ResourceLocation(affinity.getId().getNamespace(), "item/" + itemId.getPath() + "_" + affinity.getId().getPath()));
                 }
             }
             if (item instanceof SpellBookItem) {

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/model/item/SpellItemModel.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/model/item/SpellItemModel.java
@@ -3,6 +3,7 @@ package com.github.minecraftschurlimods.arsmagicalegacy.client.model.item;
 import com.github.minecraftschurlimods.arsmagicalegacy.api.ArsMagicaAPI;
 import com.github.minecraftschurlimods.arsmagicalegacy.api.affinity.IAffinity;
 import com.github.minecraftschurlimods.arsmagicalegacy.client.ClientHelper;
+import com.github.minecraftschurlimods.arsmagicalegacy.common.init.AMAffinities;
 import com.github.minecraftschurlimods.arsmagicalegacy.common.init.AMItems;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
@@ -29,9 +30,7 @@ public class SpellItemModel extends BakedModelWrapper<BakedModel> {
         public BakedModel resolve(BakedModel model, ItemStack stack, @Nullable ClientLevel level, @Nullable LivingEntity entity, int seed) {
             var helper = ArsMagicaAPI.get().getSpellHelper();
             icon = helper.getSpellIcon(stack);
-            if (!stack.isEmpty()) {
-                affinity = helper.getSpell(stack).primaryAffinity();
-            }
+            affinity = stack.isEmpty() ? AMAffinities.NONE.get() : helper.getSpell(stack).primaryAffinity();
             return SpellItemModel.this;
         }
     };

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/block/inscriptiontable/InscriptionTableMenu.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/block/inscriptiontable/InscriptionTableMenu.java
@@ -130,7 +130,10 @@ public class InscriptionTableMenu extends AbstractContainerMenu {
     }
 
     public void createSpell() {
-        ArsMagicaLegacy.NETWORK_HANDLER.sendToServer(new InscriptionTableCreateSpellPacket(table.getBlockPos()));
+        Optional<ISpell> recipe = getSpellRecipe();
+        if (recipe.isPresent() && !recipe.get().isEmpty()) {
+            ArsMagicaLegacy.NETWORK_HANDLER.sendToServer(new InscriptionTableCreateSpellPacket(table.getBlockPos()));
+        }
     }
 
     private static class InscriptionTableSlot extends Slot {


### PR DESCRIPTION
This PR fixes 2 errors related to spells:
- The "Create Spell" button in the Inscription Table menu now doesn't give empty spells anymore if no spell is laid out yet
- Empty spells no longer cause render crashes because of missing affinities