### PR TITLE
Fix a few crashes related to capability handling

### DIFF
--- a/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/magic/IBurnoutHelper.java
+++ b/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/magic/IBurnoutHelper.java
@@ -8,13 +8,13 @@ import net.minecraft.world.entity.LivingEntity;
 public interface IBurnoutHelper {
     /**
      * @param entity The entity to get the burnout value for.
-     * @return The burnout value of the given entity.
+     * @return The burnout value of the given entity, or 0 if the entity does not have a burnout capability.
      */
     float getBurnout(LivingEntity entity);
 
     /**
      * @param entity The entity to get the maximum burnout value for.
-     * @return The maximum burnout value of the given entity.
+     * @return The maximum burnout value of the given entity, or 0 if the entity does not have a max burnout value.
      */
     float getMaxBurnout(LivingEntity entity);
 

--- a/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/magic/IManaHelper.java
+++ b/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/magic/IManaHelper.java
@@ -8,13 +8,13 @@ import net.minecraft.world.entity.LivingEntity;
 public interface IManaHelper {
     /**
      * @param entity The entity to get the mana value for.
-     * @return The mana value of the entity.
+     * @return The mana value of the entity, or 0 if the entity does not have a mana capability.
      */
     float getMana(LivingEntity entity);
 
     /**
      * @param entity The entity to get the maximum mana value for.
-     * @return The maximum mana value of the entity.
+     * @return The maximum mana value of the entity, or 0 if the entity does not have a max mana value.
      */
     float getMaxMana(LivingEntity entity);
 

--- a/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/magic/IRiftHelper.java
+++ b/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/magic/IRiftHelper.java
@@ -1,6 +1,7 @@
 package com.github.minecraftschurlimods.arsmagicalegacy.api.magic;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 /**
@@ -11,5 +12,5 @@ public interface IRiftHelper {
      * @param player The player to get the rift item handler for.
      * @return The rift item handler for the given player.
      */
-    IItemHandlerModifiable getRift(Player player);
+    LazyOptional<? extends IItemHandlerModifiable> getRift(Player player);
 }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/hud/BurnoutHUD.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/hud/BurnoutHUD.java
@@ -21,6 +21,8 @@ public final class BurnoutHUD extends AbstractHUD {
             burnout = burnoutHelper.getBurnout(player);
             maxBurnout = burnoutHelper.getMaxBurnout(player);
         }
-        renderBar(mStack, xStart, yStart, 80, 10, burnout, maxBurnout, 0x880000);
+        if (maxBurnout > 0) {
+            renderBar(mStack, xStart, yStart, 80, 10, burnout, maxBurnout, 0x880000);
+        }
     }
 }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/hud/ManaHUD.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/hud/ManaHUD.java
@@ -22,6 +22,8 @@ public final class ManaHUD extends AbstractHUD {
             mana = manaHelper.getMana(player);
             maxMana = manaHelper.getMaxMana(player);
         }
-        renderBar(mStack, xStart, yStart, 80, 10, mana, maxMana, 0x99FFFF);
+        if (maxMana > 0) {
+            renderBar(mStack, xStart, yStart, 80, 10, mana, maxMana, 0x99FFFF);
+        }
     }
 }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/handler/TickHandler.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/handler/TickHandler.java
@@ -7,6 +7,7 @@ import com.github.minecraftschurlimods.arsmagicalegacy.common.ability.AbilityUUI
 import com.github.minecraftschurlimods.arsmagicalegacy.common.init.AMAbilities;
 import com.github.minecraftschurlimods.arsmagicalegacy.common.init.AMAttributes;
 import com.github.minecraftschurlimods.arsmagicalegacy.common.init.AMMobEffects;
+import com.github.minecraftschurlimods.arsmagicalegacy.common.magic.BurnoutHelper;
 import com.github.minecraftschurlimods.arsmagicalegacy.common.magic.ManaHelper;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -84,8 +85,7 @@ final class TickHandler {
 
     private static void manaAndBurnoutRegen(final Player player) {
         var api = ArsMagicaAPI.get();
-        if (player.isDeadOrDying() || !player.getCapability(ManaHelper.getManaCapability()).isPresent()) return;
-        if (!api.getMagicHelper().knowsMagic(player)) return;
+        if (player.isDeadOrDying() || !api.getMagicHelper().knowsMagic(player)) return;
         api.getManaHelper().increaseMana(player, (float) player.getAttributeValue(AMAttributes.MANA_REGEN.get()));
         api.getBurnoutHelper().decreaseBurnout(player, (float) player.getAttributeValue(AMAttributes.BURNOUT_REGEN.get()));
     }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/BurnoutHelper.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/BurnoutHelper.java
@@ -14,11 +14,15 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Consumer;
 
 public final class BurnoutHelper implements IBurnoutHelper {
     private static final Lazy<BurnoutHelper> INSTANCE = Lazy.concurrentOf(BurnoutHelper::new);
     private static final Capability<BurnoutHolder> BURNOUT = CapabilityManager.get(new CapabilityToken<>() {});
+    private static final BurnoutHolder EMPTY = new BurnoutHolder();
 
     private BurnoutHelper() {
     }
@@ -42,53 +46,57 @@ public final class BurnoutHelper implements IBurnoutHelper {
     }
 
     @Override
-    public float getBurnout(LivingEntity livingEntity) {
-        return getBurnoutHolder(livingEntity).getBurnout();
+    public float getBurnout(LivingEntity entity) {
+        return getBurnoutHolder(entity).orElse(EMPTY).getBurnout();
     }
 
     @Override
-    public float getMaxBurnout(LivingEntity livingEntity) {
-        return (float) livingEntity.getAttributeValue(AMAttributes.MAX_BURNOUT.get());
+    public float getMaxBurnout(LivingEntity entity) {
+        return entity.getAttributes().hasAttribute(AMAttributes.MAX_BURNOUT.get()) ? (float) entity.getAttributeValue(AMAttributes.MAX_BURNOUT.get()) : 0f;
     }
 
     @Override
-    public boolean increaseBurnout(LivingEntity livingEntity, float amount) {
+    public boolean increaseBurnout(LivingEntity entity, float amount) {
         if (amount < 0) return false;
-        float max = getMaxBurnout(livingEntity);
-        BurnoutHelper.BurnoutHolder magicHolder = getBurnoutHolder(livingEntity);
-        float current = magicHolder.getBurnout();
-        magicHolder.setBurnout(Math.min(current + amount, max));
-        if (livingEntity instanceof Player player) {
-            syncBurnout(player);
-        }
+        runIfPresent(entity, holder -> {
+            float max = getMaxBurnout(entity);
+            float current = holder.getBurnout();
+            holder.setBurnout(Math.min(current + amount, max));
+            if (entity instanceof Player player) {
+                syncBurnout(player);
+            }
+        });
         return true;
     }
 
     @Override
-    public boolean decreaseBurnout(LivingEntity livingEntity, float amount) {
+    public boolean decreaseBurnout(LivingEntity entity, float amount) {
         if (amount < 0) return false;
-        BurnoutHelper.BurnoutHolder magicHolder = getBurnoutHolder(livingEntity);
-        float current = magicHolder.getBurnout();
-        if (current - amount < 0) {
-            amount = current;
-        }
-        magicHolder.setBurnout(current - amount);
-        if (livingEntity instanceof Player player) {
-            syncBurnout(player);
-        }
+        runIfPresent(entity, holder -> {
+            float current = holder.getBurnout();
+            holder.setBurnout(current - amount > 0 ? current - amount : 0);
+            if (entity instanceof Player player) {
+                syncBurnout(player);
+            }
+        });
         return true;
     }
 
     @Override
     public boolean setBurnout(LivingEntity entity, float amount) {
-        if (amount < 0) throw new IllegalArgumentException("Burnout cannot be negative!");
-        float max = getMaxBurnout(entity);
-        BurnoutHelper.BurnoutHolder magicHolder = getBurnoutHolder(entity);
-        magicHolder.setBurnout(Math.min(amount, max));
-        if (entity instanceof Player player) {
-            syncBurnout(player);
-        }
+        if (amount < 0) return false;
+        runIfPresent(entity, holder -> {
+            float max = getMaxBurnout(entity);
+            holder.setBurnout(Math.min(amount, max));
+            if (entity instanceof Player player) {
+                syncBurnout(player);
+            }
+        });
         return true;
+    }
+
+    public void runIfPresent(LivingEntity entity, Consumer<BurnoutHolder> consumer) {
+        getBurnoutHolder(entity).ifPresent(consumer::accept);
     }
 
     /**
@@ -100,7 +108,7 @@ public final class BurnoutHelper implements IBurnoutHelper {
     public void syncOnDeath(Player original, Player player) {
         player.getAttribute(AMAttributes.MAX_BURNOUT.get()).setBaseValue(original.getAttribute(AMAttributes.MAX_BURNOUT.get()).getBaseValue());
         player.getAttribute(AMAttributes.BURNOUT_REGEN.get()).setBaseValue(original.getAttribute(AMAttributes.BURNOUT_REGEN.get()).getBaseValue());
-        original.getCapability(BurnoutHelper.BURNOUT).ifPresent(burnoutHolder -> player.getCapability(BurnoutHelper.BURNOUT).ifPresent(holder -> holder.onSync(burnoutHolder)));
+        original.getCapability(BURNOUT).ifPresent(burnoutHolder -> player.getCapability(BURNOUT).ifPresent(holder -> holder.onSync(burnoutHolder)));
         syncBurnout(player);
     }
 
@@ -110,14 +118,14 @@ public final class BurnoutHelper implements IBurnoutHelper {
      * @param player The player to sync to.
      */
     public void syncBurnout(Player player) {
-        ArsMagicaLegacy.NETWORK_HANDLER.sendToPlayer(new BurnoutHelper.BurnoutSyncPacket(getBurnoutHolder(player)), player);
+        runIfPresent(player, holder -> ArsMagicaLegacy.NETWORK_HANDLER.sendToPlayer(new BurnoutSyncPacket(holder), player));
     }
 
-    private BurnoutHelper.BurnoutHolder getBurnoutHolder(LivingEntity livingEntity) {
+    private LazyOptional<BurnoutHolder> getBurnoutHolder(LivingEntity livingEntity) {
         if (livingEntity instanceof Player && livingEntity.isDeadOrDying()) {
             livingEntity.reviveCaps();
         }
-        BurnoutHelper.BurnoutHolder burnoutHolder = livingEntity.getCapability(BurnoutHelper.BURNOUT).orElseThrow(() -> new RuntimeException("Could not retrieve burnout capability for LivingEntity %s{%s}".formatted(livingEntity.getDisplayName().getString(), livingEntity.getUUID())));
+        LazyOptional<BurnoutHolder> burnoutHolder = livingEntity.getCapability(BURNOUT);
         if (livingEntity instanceof Player && livingEntity.isDeadOrDying()) {
             livingEntity.invalidateCaps();
         }
@@ -146,9 +154,9 @@ public final class BurnoutHelper implements IBurnoutHelper {
 
     public static final class BurnoutHolder {
         public static final Codec<BurnoutHolder> CODEC = RecordCodecBuilder.create(inst -> inst.group(Codec.FLOAT.fieldOf("burnout").forGetter(BurnoutHolder::getBurnout)).apply(inst, burnout -> {
-            BurnoutHolder manaHolder = new BurnoutHolder();
-            manaHolder.setBurnout(burnout);
-            return manaHolder;
+            BurnoutHolder burnoutHolder = new BurnoutHolder();
+            burnoutHolder.setBurnout(burnout);
+            return burnoutHolder;
         }));
         private float burnout;
 

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/BurnoutHelper.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/BurnoutHelper.java
@@ -74,7 +74,7 @@ public final class BurnoutHelper implements IBurnoutHelper {
         if (amount < 0) return false;
         runIfPresent(entity, holder -> {
             float current = holder.getBurnout();
-            holder.setBurnout(current - amount > 0 ? current - amount : 0);
+            holder.setBurnout(Math.max(current - amount, 0));
             if (entity instanceof Player player) {
                 syncBurnout(player);
             }
@@ -117,17 +117,17 @@ public final class BurnoutHelper implements IBurnoutHelper {
      *
      * @param player The player to sync to.
      */
-    public void syncBurnout(Player player) {
+    private void syncBurnout(Player player) {
         runIfPresent(player, holder -> ArsMagicaLegacy.NETWORK_HANDLER.sendToPlayer(new BurnoutSyncPacket(holder), player));
     }
 
-    private LazyOptional<BurnoutHolder> getBurnoutHolder(LivingEntity livingEntity) {
-        if (livingEntity instanceof Player && livingEntity.isDeadOrDying()) {
-            livingEntity.reviveCaps();
+    private LazyOptional<BurnoutHolder> getBurnoutHolder(LivingEntity entity) {
+        if (entity instanceof Player && entity.isDeadOrDying()) {
+            entity.reviveCaps();
         }
-        LazyOptional<BurnoutHolder> burnoutHolder = livingEntity.getCapability(BURNOUT);
-        if (livingEntity instanceof Player && livingEntity.isDeadOrDying()) {
-            livingEntity.invalidateCaps();
+        LazyOptional<BurnoutHolder> burnoutHolder = entity.getCapability(BURNOUT);
+        if (entity instanceof Player && entity.isDeadOrDying()) {
+            entity.invalidateCaps();
         }
         return burnoutHolder;
     }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/BurnoutHelper.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/BurnoutHelper.java
@@ -95,10 +95,6 @@ public final class BurnoutHelper implements IBurnoutHelper {
         return true;
     }
 
-    public void runIfPresent(LivingEntity entity, Consumer<BurnoutHolder> consumer) {
-        getBurnoutHolder(entity).ifPresent(consumer::accept);
-    }
-
     /**
      * Called on player death, syncs the capability.
      *
@@ -117,8 +113,12 @@ public final class BurnoutHelper implements IBurnoutHelper {
      *
      * @param player The player to sync to.
      */
-    private void syncBurnout(Player player) {
+    public void syncBurnout(Player player) {
         runIfPresent(player, holder -> ArsMagicaLegacy.NETWORK_HANDLER.sendToPlayer(new BurnoutSyncPacket(holder), player));
+    }
+
+    private void runIfPresent(LivingEntity entity, Consumer<BurnoutHolder> consumer) {
+        getBurnoutHolder(entity).ifPresent(consumer::accept);
     }
 
     private LazyOptional<BurnoutHolder> getBurnoutHolder(LivingEntity entity) {

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/MagicHelper.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/MagicHelper.java
@@ -17,12 +17,15 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Consumer;
 
 public final class MagicHelper implements IMagicHelper {
     private static final Lazy<MagicHelper> INSTANCE = Lazy.concurrentOf(MagicHelper::new);
-    private static final Capability<MagicHolder> MAGIC = CapabilityManager.get(new CapabilityToken<>() {
-    });
+    private static final Capability<MagicHolder> MAGIC = CapabilityManager.get(new CapabilityToken<>() {});
+    private static final MagicHolder EMPTY = new MagicHolder();
 
     private MagicHelper() {
     }
@@ -47,12 +50,12 @@ public final class MagicHelper implements IMagicHelper {
 
     @Override
     public int getLevel(Player player) {
-        return getMagicHolder(player).getLevel();
+        return getMagicHolder(player).orElse(EMPTY).getLevel();
     }
 
     @Override
     public float getXp(Player player) {
-        return getMagicHolder(player).getXp();
+        return getMagicHolder(player).orElse(EMPTY).getXp();
     }
 
     @Override
@@ -67,22 +70,23 @@ public final class MagicHelper implements IMagicHelper {
 
     @Override
     public void setXp(Player player, float amount) {
-        MagicHolder magicHolder = getMagicHolder(player);
-        int level = magicHolder.getLevel();
-        float xp = Math.max(0, amount);
-        float xpForNextLevel = getXpForNextLevel(level);
-        while (xp >= xpForNextLevel) {
-            xp -= xpForNextLevel;
-            level++;
-            MinecraftForge.EVENT_BUS.post(new PlayerLevelUpEvent(player, level));
-            if (player instanceof ServerPlayer serverPlayer) {
-                AMCriteriaTriggers.PLAYER_LEVEL_UP.trigger(serverPlayer, level);
+        runIfPresent(player, holder -> {
+            int level = holder.getLevel();
+            float xp = Math.max(0, amount);
+            float xpForNextLevel = getXpForNextLevel(level);
+            while (xp >= xpForNextLevel) {
+                xp -= xpForNextLevel;
+                level++;
+                MinecraftForge.EVENT_BUS.post(new PlayerLevelUpEvent(player, level));
+                if (player instanceof ServerPlayer sp) {
+                    AMCriteriaTriggers.PLAYER_LEVEL_UP.trigger(sp, level);
+                }
+                xpForNextLevel = getXpForNextLevel(level);
             }
-            xpForNextLevel = getXpForNextLevel(level);
-        }
-        magicHolder.setXp(xp);
-        magicHolder.setLevel(level);
-        syncMagic(player);
+            holder.setXp(xp);
+            holder.setLevel(level);
+            syncMagic(player);
+        });
     }
 
     @Override
@@ -92,18 +96,19 @@ public final class MagicHelper implements IMagicHelper {
 
     @Override
     public void setLevel(Player player, int level) {
-        MagicHolder magicHolder = getMagicHolder(player);
-        int oldLevel = magicHolder.getLevel();
-        magicHolder.setLevel(level);
-        if (level > oldLevel && level > 0) {
-            for (int i = oldLevel + 1; i <= level; i++) {
-                MinecraftForge.EVENT_BUS.post(new PlayerLevelUpEvent(player, i));
-                if (player instanceof ServerPlayer serverPlayer) {
-                    AMCriteriaTriggers.PLAYER_LEVEL_UP.trigger(serverPlayer, level);
+        runIfPresent(player, holder -> {
+            int oldLevel = holder.getLevel();
+            holder.setLevel(level);
+            if (level > oldLevel && level > 0) {
+                for (int i = oldLevel + 1; i <= level; i++) {
+                    MinecraftForge.EVENT_BUS.post(new PlayerLevelUpEvent(player, i));
+                    if (player instanceof ServerPlayer sp) {
+                        AMCriteriaTriggers.PLAYER_LEVEL_UP.trigger(sp, level);
+                    }
                 }
             }
-        }
-        syncMagic(player);
+            syncMagic(player);
+        });
     }
 
     @Override
@@ -128,18 +133,22 @@ public final class MagicHelper implements IMagicHelper {
      * @param player The player to sync to.
      */
     public void syncMagic(Player player) {
-        ArsMagicaLegacy.NETWORK_HANDLER.sendToPlayer(new MagicSyncPacket(getMagicHolder(player)), player);
+        runIfPresent(player, holder -> ArsMagicaLegacy.NETWORK_HANDLER.sendToPlayer(new MagicSyncPacket(holder), player));
     }
 
-    private MagicHolder getMagicHolder(Player player) {
+    private LazyOptional<MagicHolder> getMagicHolder(Player player) {
         if (player.isDeadOrDying()) {
             player.reviveCaps();
         }
-        MagicHolder magicHolder = player.getCapability(MAGIC).orElseThrow(() -> new RuntimeException("Could not retrieve magic capability for player %s{%s}".formatted(player.getDisplayName().getString(), player.getUUID())));
+        LazyOptional<MagicHolder> magicHolder = player.getCapability(MAGIC);
         if (player.isDeadOrDying()) {
             player.invalidateCaps();
         }
         return magicHolder;
+    }
+
+    private void runIfPresent(Player player, Consumer<MagicHolder> consumer) {
+        getMagicHolder(player).ifPresent(consumer::accept);
     }
 
     public static final class MagicSyncPacket extends CodecPacket<MagicHolder> {

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/RiftHelper.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/RiftHelper.java
@@ -8,6 +8,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.ItemStackHandler;
 
 public final class RiftHelper implements IRiftHelper {
@@ -32,8 +33,8 @@ public final class RiftHelper implements IRiftHelper {
     }
 
     @Override
-    public ItemStackHandler getRift(Player player) {
-        return player.getCapability(RIFT).orElseThrow(() -> new RuntimeException("Could not retrieve rift capability for LivingEntity %s{%s}".formatted(player.getGameProfile().getName(), player.getGameProfile().getId())));
+    public LazyOptional<? extends ItemStackHandler> getRift(Player player) {
+        return player.getCapability(RIFT);
     }
 
     /**

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/rift/RiftMenu.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/rift/RiftMenu.java
@@ -14,6 +14,8 @@ public class RiftMenu extends ChestMenu {
     }
 
     /**
+     * IMPORTANT: Wrap all calls to this inside a {@code ArsMagicaAPI.get().getRiftHelper().getRift(player).isPresent()} check, and handle failing that check accordingly.
+     *
      * @param windowId The window id to use.
      * @param inv      The inventory to use.
      * @param buf      The buffer to read the uuid and the rift size from.
@@ -24,6 +26,8 @@ public class RiftMenu extends ChestMenu {
     }
 
     /**
+     * IMPORTANT: Wrap all calls to this inside a {@code ArsMagicaAPI.get().getRiftHelper().getRift(player).isPresent()} check, and handle failing that check accordingly.
+     *
      * @param windowId The window id to use.
      * @param inv      The inventory to use.
      * @param player   The player this rift belongs to.
@@ -31,6 +35,6 @@ public class RiftMenu extends ChestMenu {
      * @return A rift menu.
      */
     public static RiftMenu rift(int windowId, Inventory inv, Player player, int size) {
-        return new RiftMenu(windowId, inv, new RiftContainer(ArsMagicaAPI.get().getRiftHelper().getRift(player)), size);
+        return new RiftMenu(windowId, inv, new RiftContainer(ArsMagicaAPI.get().getRiftHelper().getRift(player).orElseThrow(() -> new RuntimeException("Could not retrieve rift capability for LivingEntity %s{%s}".formatted(player.getGameProfile().getName(), player.getGameProfile().getId())))), size);
     }
 }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/spell/component/Rift.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/spell/component/Rift.java
@@ -27,7 +27,7 @@ public class Rift extends AbstractComponent {
 
     @Override
     public SpellCastResult invoke(ISpell spell, LivingEntity caster, Level level, List<ISpellModifier> modifiers, EntityHitResult target, int index, int ticksUsed) {
-        if (target.getEntity() instanceof ServerPlayer sp) {
+        if (target.getEntity() instanceof ServerPlayer sp && ArsMagicaAPI.get().getRiftHelper().getRift(sp).isPresent()) {
             int size = Math.min(Math.round(Math.max(1, ArsMagicaAPI.get().getSpellHelper().getModifiedStat(1, SpellPartStats.POWER, modifiers, spell, caster, target))), PermissionAPI.getPermission(sp, AMPermissions.MAX_RIFT_SIZE));
             NetworkHooks.openGui(sp, new SimpleMenuProvider((id, inv, player) -> RiftMenu.rift(id, inv, sp, size), new TranslatableComponent(TranslationConstants.RIFT_TITLE)), buf -> {
                 buf.writeUUID(sp.getUUID());


### PR DESCRIPTION
This PR fixes a few issues with capability handling, mainly in the helper classes.

Most notably, instead of throwing when things are missing, default values are used.

This fixes issues such as the game crashing when applying mana regen/burnout reduction to animals, and is potentially a fix for #381 (that one is weird, so we'll have to see).

Note: This is not yet tested, will do so tomorrow.