### PR TITLE
Add compendium config

### DIFF
--- a/src/data/java/com/github/minecraftschurlimods/arsmagicalegacy/data/AMEnglishLanguageProvider.java
+++ b/src/data/java/com/github/minecraftschurlimods/arsmagicalegacy/data/AMEnglishLanguageProvider.java
@@ -350,6 +350,7 @@ class AMEnglishLanguageProvider extends AMLanguageProvider {
         skillTranslation(AMSpellParts.WAVE.getId(), "Wave", "You might not want to surf on this one.", "shapes", "You can project a wave of magic in front of you that rolls forward, applying its effect to everything in its path.");
         skillTranslation(AMSpellParts.WIZARDS_AUTUMN.getId(), "Wizard's Autumn", "Leaves must leave.", "components", "You have learned to focus your digging magic into a small radius that directly affects leaves.$(br2)This component has a built-in $(l:shapes/aoe)AoE$() that can be modified with $(l:modifiers/range)Range$() modifiers.");
         skillTranslation(AMSpellParts.ZONE.getId(), "Zone", "No one can beat me in my sanctuary!", "shapes", "You have learned to focus your will into an area effect that will persist for a time.");
+        configTranslation("require_compendium_crafting", "Whether the player needs to craft the compendium before being able to use magic. If disabled, the player can use magic from the beginning.");
         configTranslation("burnout_ratio", "The default mana to burnout ratio, used in calculating spell costs.");
         configTranslation("crafting_altar_check_time", "The time in ticks between multiblock validation checks for the crafting altar.");
         configTranslation("max_etherium_storage", "The maximum amount of etherium that can be stored in an obelisk / celestial prism / black aurem.");

--- a/src/main/generated/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
+++ b/src/main/generated/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
@@ -1,2 +1,2 @@
-// 1.19.2	2023-07-30T14:55:08.4975074	Languages: en_us
-26f09401e76a56ace62c431fd7fa76c82ca7214b assets/arsmagicalegacy/lang/en_us.json
+// 1.19.2	2023-07-30T21:54:31.5541261	Languages: en_us
+db19955573ef572647671675c9031b8f294bed8e assets/arsmagicalegacy/lang/en_us.json

--- a/src/main/generated/assets/arsmagicalegacy/lang/en_us.json
+++ b/src/main/generated/assets/arsmagicalegacy/lang/en_us.json
@@ -183,6 +183,7 @@
   "config.arsmagicalegacy.mana.regen_multiplier": "The multiplier for mana regeneration. Mana regen is calculated as (base + multiplier * (level - 1)) * regen_multiplier.",
   "config.arsmagicalegacy.max_etherium_storage": "The maximum amount of etherium that can be stored in an obelisk / celestial prism / black aurem.",
   "config.arsmagicalegacy.max_shape_groups": "The maximum number of shape groups allowed for new spells.",
+  "config.arsmagicalegacy.require_compendium_crafting": "Whether the player needs to craft the compendium before being able to use magic. If disabled, the player can use magic from the beginning.",
   "death.attack.falling_star": "%1$s was obliterated by a falling star",
   "death.attack.nature_scythe": "%1$s was ripped apart by %2$s's scythe",
   "death.attack.shockwave": "%1$s was obliterated by a shockwave",

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/Config.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/Config.java
@@ -143,6 +143,7 @@ public final class Config {
      * Class holding the server config values.
      */
     public static final class Server {
+        public final ForgeConfigSpec.BooleanValue REQUIRE_COMPENDIUM_CRAFTING;
         public final ForgeConfigSpec.DoubleValue BURNOUT_RATIO;
         public final ForgeConfigSpec.IntValue CRAFTING_ALTAR_CHECK_TIME;
         public final ForgeConfigSpec.IntValue MAX_ETHERIUM_STORAGE;
@@ -166,6 +167,10 @@ public final class Config {
         public final ForgeConfigSpec.IntValue DRYAD_KILLS_TO_NATURE_GUARDIAN_SPAWN;
 
         private Server(ForgeConfigSpec.Builder builder) {
+            REQUIRE_COMPENDIUM_CRAFTING = builder
+                    .comment("Whether the player needs to craft the compendium before being able to use magic. If disabled, the player can use magic from the beginning.")
+                    .translation(TranslationConstants.CONFIG + "require_compendium_crafting")
+                    .define("require_compendium_crafting", true);
             BURNOUT_RATIO = builder
                     .comment("The default mana to burnout ratio, used in calculating spell costs.")
                     .translation(TranslationConstants.CONFIG + "burnout_ratio")

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/handler/EventHandler.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/handler/EventHandler.java
@@ -119,7 +119,6 @@ public final class EventHandler {
         forgeBus.addListener(EventHandler::addReloadListener);
         forgeBus.addListener(EventHandler::entityJoinWorld);
         forgeBus.addListener(EventHandler::playerClone);
-        forgeBus.addListener(EventHandler::playerItemPickup);
         forgeBus.addListener(EventHandler::playerItemCrafted);
         forgeBus.addListener(EventHandler::playerRespawn);
         forgeBus.addListener(EventHandler::livingDamage);
@@ -247,21 +246,7 @@ public final class EventHandler {
         event.getOriginal().invalidateCaps();
     }
 
-    private static void playerItemPickup(PlayerEvent.ItemPickupEvent event) {
-/*
-        if (event.getPlayer().isCreative()) return;
-        if (event.getPlayer().isSpectator()) return;
-        var api = ArsMagicaAPI.get();
-        var helper = api.getMagicHelper();
-        if (helper.knowsMagic(event.getPlayer())) return;
-        if (!ItemStack.isSameItemSameTags(api.getBookStack(), event.getStack())) return;
-        helper.awardXp(event.getPlayer(), 0);
-*/
-    }
-
     private static void playerItemCrafted(PlayerEvent.ItemCraftedEvent event) {
-        if (event.getEntity().isCreative()) return;
-        if (event.getEntity().isSpectator()) return;
         var api = ArsMagicaAPI.get();
         var helper = api.getMagicHelper();
         if (helper.knowsMagic(event.getEntity())) return;

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/MagicHelper.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/magic/MagicHelper.java
@@ -111,7 +111,7 @@ public final class MagicHelper implements IMagicHelper {
 
     @Override
     public boolean knowsMagic(Player player) {
-        return player.isCreative() || player.isSpectator() || getLevel(player) > 0;
+        return !Config.SERVER.REQUIRE_COMPENDIUM_CRAFTING.get() || player.isCreative() || player.isSpectator() || getLevel(player) > 0;
     }
 
     /**


### PR DESCRIPTION
This PR adds a config option to disable the requirement of crafting the compendium in order to start with the mod. It is mainly directed at modpack makers who might want the progression to work differently (think Botania's Garden of Glass mode).