### PR TITLE
Fix a few issues found during testing

### DIFF
--- a/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/spell/ISpell.java
+++ b/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/spell/ISpell.java
@@ -48,7 +48,7 @@ public interface ISpell {
     boolean isEmpty();
 
     /**
-     * @return Whether the spell is valid or not.
+     * @return Whether all parts of the spell are non-null. To check whether a spell is actually valid from a player perspective, use {@link ISpellHelper#isValidSpell(ISpell)} instead.
      */
     boolean isValid();
 

--- a/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/spell/ISpellHelper.java
+++ b/src/api/java/com/github/minecraftschurlimods/arsmagicalegacy/api/spell/ISpellHelper.java
@@ -30,6 +30,14 @@ public interface ISpellHelper {
     void setSpell(ItemStack stack, ISpell spell);
 
     /**
+     * Validates the given spell. This checks for non-emptiness of the spell stack, the shape groups being correct, and correct location of modifiers (if present).
+     *
+     * @param spell The spell to validate.
+     * @return Whether the given spell is valid or not.
+     */
+    boolean isValidSpell(ISpell spell);
+
+    /**
      * @param stack The stack to get the spell name for.
      * @return An optional containing the spell name, or an empty optional if the given stack does not have a spell name.
      */

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/Config.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/Config.java
@@ -63,15 +63,15 @@ public final class Config {
             MANA_X = builder
                     .comment("Horizontal position of the mana bar.")
                     .translation(TranslationConstants.CONFIG + "mana_x")
-                    .defineInRange("mana_x", 210, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("mana_x", 6, Short.MIN_VALUE, Short.MAX_VALUE);
             MANA_Y = builder
                     .comment("Vertical position of the mana bar.")
                     .translation(TranslationConstants.CONFIG + "mana_y")
-                    .defineInRange("mana_y", 23, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("mana_y", 14, Short.MIN_VALUE, Short.MAX_VALUE);
             MANA_ANCHOR_X = builder
                     .comment("Horizontal anchor of the mana bar.")
                     .translation(TranslationConstants.CONFIG + "mana_anchor_x")
-                    .defineEnum("mana_anchor_x", HUDElement.AnchorX.CENTER);
+                    .defineEnum("mana_anchor_x", HUDElement.AnchorX.RIGHT);
             MANA_ANCHOR_Y = builder
                     .comment("Horizontal anchor of the mana bar.")
                     .translation(TranslationConstants.CONFIG + "mana_anchor_y")
@@ -81,15 +81,15 @@ public final class Config {
             BURNOUT_X = builder
                     .comment("Horizontal position of the burnout bar.")
                     .translation(TranslationConstants.CONFIG + "burnout_x")
-                    .defineInRange("burnout_x", 210, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("burnout_x", 6, Short.MIN_VALUE, Short.MAX_VALUE);
             BURNOUT_Y = builder
                     .comment("Vertical position of the burnout bar.")
                     .translation(TranslationConstants.CONFIG + "burnout_y")
-                    .defineInRange("burnout_y", 13, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("burnout_y", 4, Short.MIN_VALUE, Short.MAX_VALUE);
             BURNOUT_ANCHOR_X = builder
                     .comment("Horizontal anchor of the burnout bar.")
                     .translation(TranslationConstants.CONFIG + "burnout_anchor_x")
-                    .defineEnum("burnout_anchor_x", HUDElement.AnchorX.CENTER);
+                    .defineEnum("burnout_anchor_x", HUDElement.AnchorX.RIGHT);
             BURNOUT_ANCHOR_Y = builder
                     .comment("Horizontal anchor of the burnout bar.")
                     .translation(TranslationConstants.CONFIG + "burnout_anchor_y")
@@ -99,15 +99,15 @@ public final class Config {
             XP_X = builder
                     .comment("Horizontal position of the magic xp bar.")
                     .translation(TranslationConstants.CONFIG + "xp_x")
-                    .defineInRange("xp_x", 210, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("xp_x", 6, Short.MIN_VALUE, Short.MAX_VALUE);
             XP_Y = builder
                     .comment("Vertical position of the magic xp bar.")
                     .translation(TranslationConstants.CONFIG + "xp_y")
-                    .defineInRange("xp_y", 33, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("xp_y", 24, Short.MIN_VALUE, Short.MAX_VALUE);
             XP_ANCHOR_X = builder
                     .comment("Horizontal anchor of the magic xp bar.")
                     .translation(TranslationConstants.CONFIG + "xp_anchor_x")
-                    .defineEnum("xp_anchor_x", HUDElement.AnchorX.CENTER);
+                    .defineEnum("xp_anchor_x", HUDElement.AnchorX.RIGHT);
             XP_ANCHOR_Y = builder
                     .comment("Horizontal anchor of the magic xp bar.")
                     .translation(TranslationConstants.CONFIG + "xp_anchor_y")
@@ -117,11 +117,11 @@ public final class Config {
             SPELL_BOOK_X = builder
                     .comment("Horizontal position of the spell book hud.")
                     .translation(TranslationConstants.CONFIG + "spell_book_x")
-                    .defineInRange("spell_book_x", 100, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("spell_book_x", -129, Short.MIN_VALUE, Short.MAX_VALUE);
             SPELL_BOOK_Y = builder
                     .comment("Vertical position of the spell book hud.")
                     .translation(TranslationConstants.CONFIG + "spell_book_y")
-                    .defineInRange("spell_book_y", 19, Short.MIN_VALUE, Short.MAX_VALUE);
+                    .defineInRange("spell_book_y", 18, Short.MIN_VALUE, Short.MAX_VALUE);
             SPELL_BOOK_ANCHOR_X = builder
                     .comment("Horizontal anchor of the spell book hud.")
                     .translation(TranslationConstants.CONFIG + "spell_book_anchor_x")

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/ClientInit.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/ClientInit.java
@@ -332,12 +332,12 @@ public final class ClientInit {
         int color = 0xff0000; //TODO change when Color modifier is added
         for (Player p : level.players()) {
             if (player.distanceTo(p) > dist || !p.isUsingItem()) continue;
-            ItemStack stack = p.getMainHandItem();
             InteractionHand hand = InteractionHand.MAIN_HAND;
+            ItemStack stack = getSpellInHand(p, hand);
             if (!(stack.getItem() instanceof ISpellItem)) {
-                stack = p.getOffhandItem();
-                if (!(stack.getItem() instanceof ISpellItem)) continue;
                 hand = InteractionHand.OFF_HAND;
+                stack = getSpellInHand(p, hand);
+                if (!(stack.getItem() instanceof ISpellItem)) continue;
             }
             ISpell spell = helper.getSpell(stack);
             Pair<ISpellShape, List<ISpellModifier>> pair = spell.currentShapeGroup().shapesWithModifiers().get(0);
@@ -358,5 +358,13 @@ public final class ClientInit {
                 }
             }
         }
+    }
+
+    private static ItemStack getSpellInHand(Player player, InteractionHand hand) {
+        ItemStack stack = player.getItemInHand(hand);
+        if (stack.getItem() instanceof SpellBookItem) {
+            stack = SpellBookItem.getSelectedSpell(stack);
+        }
+        return stack;
     }
 }

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/gui/inscriptiontable/InscriptionTableScreen.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/client/gui/inscriptiontable/InscriptionTableScreen.java
@@ -60,9 +60,11 @@ public class InscriptionTableScreen extends AbstractContainerScreen<InscriptionT
         if (Objects.requireNonNull(getMinecraft().player).isCreative()) {
             addRenderableWidget(new Button(leftPos + 72, topPos + 72, 100, 20, Component.translatable(TranslationConstants.INSCRIPTION_TABLE_CREATE_SPELL), button -> {
                 sync();
-                if (shapeGroupArea.isValid() && !spellGrammarArea.getAll().isEmpty()) {
-                    menu.createSpell();
-                }
+                menu.getSpellRecipe().ifPresent(e -> {
+                    if (ArsMagicaAPI.get().getSpellHelper().isValidSpell(e)) {
+                        menu.createSpell();
+                    }
+                });
             }));
         }
         sourceArea = new SpellPartSourceArea(leftPos + 42, topPos + 6, 136, 48);

--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/block/inscriptiontable/InscriptionTableMenu.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/block/inscriptiontable/InscriptionTableMenu.java
@@ -156,6 +156,7 @@ public class InscriptionTableMenu extends AbstractContainerMenu {
 
         @Override
         public Optional<ItemStack> tryRemove(int p_150642_, int p_150643_, Player player) {
+            if (table.getSpellRecipe() != null && !ArsMagicaAPI.get().getSpellHelper().isValidSpell(table.getSpellRecipe())) return super.tryRemove(p_150642_, p_150643_, player);
             player.getLevel().playSound(null, table.getBlockPos().getX(), table.getBlockPos().getY(), table.getBlockPos().getZ(), AMSounds.INSCRIPTION_TABLE_TAKE_BOOK.get(), SoundSource.BLOCKS, 1f, 1f);
             return super.tryRemove(p_150642_, p_150643_, player).flatMap(stack -> stack.getItem() instanceof ISpellItem ? Optional.of(stack) : table.saveRecipe(stack));
         }


### PR DESCRIPTION
During testing for the new versions, I found a few issues. I traced the issues back to 1.19.2 and subsequently fixed them on that version already. The issues are:

- The Inscription Table's book slot not checking for spell validity before creating the spell recipe
- Beams not correctly rendering when the spell is in a spell book
- Default client config values weren't properly aligned with anything, some of them were even overlapping with the vanilla inventory

After this PR is merged, the newer version branches should be rebased on 1.19.2 once again.