### PR TITLE
Rebalance affinity essence requirements for spell recipes

### DIFF
--- a/src/data/java/com/github/minecraftschurlimods/arsmagicalegacy/data/AMSpellPartDataProvider.java
+++ b/src/data/java/com/github/minecraftschurlimods/arsmagicalegacy/data/AMSpellPartDataProvider.java
@@ -31,7 +31,6 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
     protected void generate() {
         var helper = ArsMagicaAPI.get().getAffinityHelper();
         builder(AMSpellParts.AOE, 2f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.ICE.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.TNT), 1))
                 .addIngredient(new EtheriumSpellIngredient(EnumSet.of(EtheriumType.LIGHT, EtheriumType.NEUTRAL, EtheriumType.DARK), 1))
                 .build();
@@ -122,10 +121,10 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .addIngredient(new EtheriumSpellIngredient(EnumSet.of(EtheriumType.LIGHT, EtheriumType.NEUTRAL, EtheriumType.DARK), 2500))
                 .build();
         builder(AMSpellParts.ZONE, 2.5f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.AIR.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMTags.Items.GEMS_MOONSTONE), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMTags.Items.GEMS_SUNSTONE), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMItems.TARMA_ROOT.get()), 1))
+                .addIngredient(new EtheriumSpellIngredient(EnumSet.of(EtheriumType.LIGHT, EtheriumType.NEUTRAL, EtheriumType.DARK), 2500))
                 .build();
         builder(AMSpellParts.DROWNING_DAMAGE, 25f)
                 .addAffinity(AMAffinities.WATER, 0.001f)
@@ -189,6 +188,7 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .build();
         builder(AMSpellParts.HEALTH_BOOST, 50f)
                 .addAffinity(AMAffinities.LIFE, 0.001f)
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.LIFE.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMItems.COLORED_RUNE.get(DyeColor.LIGHT_BLUE)), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.ENCHANTED_GOLDEN_APPLE), 1))
                 .build();
@@ -555,7 +555,7 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMItems.WITCHWOOD_SAPLING.get()), 1))
                 .build();
         builder(AMSpellParts.BOUNCE, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.LIGHTNING.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.WATER.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.SLIMEBALLS), 1))
                 .build();
         builder(AMSpellParts.DAMAGE, 1.25f)
@@ -564,12 +564,12 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(PotionUtils.setPotion(new ItemStack(Items.POTION), Potions.HARMING)), 1))
                 .build();
         builder(AMSpellParts.DISMEMBERING, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.FIRE.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.ICE.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.BONES), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.WITHER_SKELETON_SKULL), 1))
                 .build();
         builder(AMSpellParts.DURATION, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.ENDER.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.AIR.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.SLIMEBALLS), 1))
                 .build();
         builder(AMSpellParts.EFFECT_POWER, 1.25f)
@@ -582,7 +582,7 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.SPIDER_EYE), 1))
                 .build();
         builder(AMSpellParts.GRAVITY, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.ENDER.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.EARTH.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.COMPASS), 1))
                 .build();
         builder(AMSpellParts.HEALING, 1.25f)
@@ -600,17 +600,17 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.GEMS_DIAMOND), 1))
                 .build();
         builder(AMSpellParts.PIERCING, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.ICE.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.WATER.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.ARROW), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.SNOWBALL), 1))
                 .build();
         builder(AMSpellParts.PROSPERITY, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.EARTH.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.ICE.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.INGOTS_GOLD), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.GEMS_EMERALD), 1))
                 .build();
         builder(AMSpellParts.RANGE, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.WATER.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.AIR.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.DUSTS_REDSTONE), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Items.ARROW), 1))
                 .build();
@@ -622,7 +622,7 @@ class AMSpellPartDataProvider extends SpellPartDataProvider {
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMItems.COLORED_RUNE.get(DyeColor.WHITE)), 1))
                 .build();
         builder(AMSpellParts.SILK_TOUCH, 1.25f)
-                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.AIR.get())), 1))
+                .addIngredient(new IngredientSpellIngredient(StrictNBTIngredient.of(helper.getStackForAffinity(AMItems.AFFINITY_ESSENCE.get(), AMAffinities.EARTH.get())), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(AMTags.Items.GEMS_CHIMERITE), 1))
                 .addIngredient(new IngredientSpellIngredient(Ingredient.of(Tags.Items.FEATHERS), 1))
                 .build();

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/aoe.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/aoe.json
@@ -7,16 +7,6 @@
       "type": "arsmagicalegacy:ingredient",
       "count": 1,
       "ingredient": {
-        "type": "forge:nbt",
-        "count": 1,
-        "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:ice\"}"
-      }
-    },
-    {
-      "type": "arsmagicalegacy:ingredient",
-      "count": 1,
-      "ingredient": {
         "item": "minecraft:tnt"
       }
     },

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/bounce.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/bounce.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:lightning\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:water\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/dismembering.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/dismembering.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:fire\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:ice\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/duration.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/duration.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:ender\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:air\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/gravity.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/gravity.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:ender\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:earth\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/health_boost.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/health_boost.json
@@ -9,6 +9,16 @@
       "type": "arsmagicalegacy:ingredient",
       "count": 1,
       "ingredient": {
+        "type": "forge:nbt",
+        "count": 1,
+        "item": "arsmagicalegacy:affinity_essence",
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:life\"}"
+      }
+    },
+    {
+      "type": "arsmagicalegacy:ingredient",
+      "count": 1,
+      "ingredient": {
         "item": "arsmagicalegacy:light_blue_rune"
       }
     },

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/piercing.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/piercing.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:ice\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:water\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/prosperity.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/prosperity.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:earth\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:ice\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/range.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/range.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:water\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:air\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/silk_touch.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/silk_touch.json
@@ -10,7 +10,7 @@
         "type": "forge:nbt",
         "count": 1,
         "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:air\"}"
+        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:earth\"}"
       }
     },
     {

--- a/src/main/generated/data/arsmagicalegacy/spell_parts/zone.json
+++ b/src/main/generated/data/arsmagicalegacy/spell_parts/zone.json
@@ -7,16 +7,6 @@
       "type": "arsmagicalegacy:ingredient",
       "count": 1,
       "ingredient": {
-        "type": "forge:nbt",
-        "count": 1,
-        "item": "arsmagicalegacy:affinity_essence",
-        "nbt": "{\"arsmagicalegacy:affinity\":\"arsmagicalegacy:air\"}"
-      }
-    },
-    {
-      "type": "arsmagicalegacy:ingredient",
-      "count": 1,
-      "ingredient": {
         "tag": "forge:gems/moonstone"
       }
     },
@@ -33,6 +23,15 @@
       "ingredient": {
         "item": "arsmagicalegacy:tarma_root"
       }
+    },
+    {
+      "type": "arsmagicalegacy:etherium",
+      "amount": 2500,
+      "types": [
+        "LIGHT",
+        "NEUTRAL",
+        "DARK"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR changes the affinity essence requirements for spell recipes.
- AoE no longer requires an Ice Affinity Essence (removing the effective locking of AoE and all subsequent parts at around level 60)
- Zone no longer requires an Air Affinity Essence, instead requiring 2500 of any etherium type
- Health Boost now requires a Life Affinity Essence
- Changed the essence types for some parts; making early-game parts require early-game essences and not something like Fire, and at the same time making late-game parts require late-game essences and not something like Earth