### PR TITLE
Fix magic xp not scaling with stronger spells

### DIFF
--- a/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/spell/Spell.java
+++ b/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/spell/Spell.java
@@ -178,9 +178,8 @@ public final class Spell implements ISpell {
                     MinecraftForge.EVENT_BUS.post(new AffinityChangingEvent.Post(player, affinity, shift.floatValue(), false));
                 }
             }
-            float xp = 0.05f * affinityShifts.size();
+            float xp = (float) affinityShifts().values().stream().mapToDouble(e -> e).sum() * affinityShifts.size() * 100;
             if (continuous) xp /= 4;
-            if (affinityGains) xp *= 0.9f;
             api.getMagicHelper().awardXp(player, xp);
         }
         return result;


### PR DESCRIPTION
Changes the amount of magic xp rewarded by casting spells to properly scale with stronger spells (= spells that have stronger affinity gains). Also changes the base amount of xp awarded, making early leveling a bit faster.