### PR TITLE
Enable log coloring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,9 @@ runs {
             enabled = false
         }
     }
+    all {
+        systemProperties.put("terminal.ansi", "true")
+    }
 }
 
 helper.publication.pom {


### PR DESCRIPTION
Sets the `terminal.ansi` property to true for all runs, causing IntelliJ log output to be colored as it used to be in older versions.